### PR TITLE
Use a variable for api app hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ DB_CLIENT_ID
 DB_CLIENT_SECRET
 DB_ACCOUNT
 DB_API_ENDPOINT_BASEURI
+REDIRECT_BASE_URL
 YNAB_SECRET
 YNAB_BUDGET_ID
 YNAB_ACCOUNT_ID
@@ -25,6 +26,8 @@ YNAB_ACCOUNT_ID
 You have to create an App at [developer.db.com](https://developer.db.com) to get the DB client ID and secret. Note that there is a slow (~2 weeks!) process for approval to get access to real live bank data. `DB_ACCOUNT` is either the IBAN of a cash account, or the last 4 digits of a credit card number. `DB_API_ENDPOINT_HOSTNAME` is the hostname of the DB api endpoint. It is `https://simulator-api.db.com/` for apps in the sandbox, and `https://api.db.com/` for live apps.
 
 [Create a YNAB personal access token](https://api.youneedabudget.com/#personal-access-tokens) to use as your YNAB secret. The budget and account IDs are UUIDs you can get from the URL of the target account. For example, when viewing your account the URL may be `https://app.youneedabudget.com/ba1f67f1-5fba-4314-b4a3-94256409ff57/accounts/822de6c0-6967-4ad3-d4cf-f227dd58a7f9`. In that case the Budget ID is `ba1f67f1-5fba-4314-b4a3-94256409ff57`, and the account ID is `822de6c0-6967-4ad3-d4cf-f227dd58a7f9`.
+
+`REDIRECT_BASE_URL` is the accessible (to you) URL of this application. As a part of the DB authentication flow, the DB API has to validate that it is redirecting you to an allowed URL (per your API app).
 
 With those env vars in `.env`, you're ready to run the application.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You have to create an App at [developer.db.com](https://developer.db.com) to get
 
 [Create a YNAB personal access token](https://api.youneedabudget.com/#personal-access-tokens) to use as your YNAB secret. The budget and account IDs are UUIDs you can get from the URL of the target account. For example, when viewing your account the URL may be `https://app.youneedabudget.com/ba1f67f1-5fba-4314-b4a3-94256409ff57/accounts/822de6c0-6967-4ad3-d4cf-f227dd58a7f9`. In that case the Budget ID is `ba1f67f1-5fba-4314-b4a3-94256409ff57`, and the account ID is `822de6c0-6967-4ad3-d4cf-f227dd58a7f9`.
 
-`REDIRECT_BASE_URL` is the accessible (to you) URL of this application. As a part of the DB authentication flow, the DB API has to validate that it is redirecting you to an allowed URL (per your API app).
+`REDIRECT_BASE_URL` is the accessible (to you) URL of this application. As a part of the DB authentication flow, the DB API has to validate that it is redirecting you to an allowed URL (per your API app). This value should end in a `/`, e.g. `https://example.com/my-bank-sync/`.
 
 With those env vars in `.env`, you're ready to run the application.
 

--- a/dbapi/cashaccount.go
+++ b/dbapi/cashaccount.go
@@ -32,6 +32,11 @@ var ynabAccountID string = os.Getenv("YNAB_ACCOUNT_ID")
 // DbCashConnector gets transactions from a DB Cash account and converts to YNAB format.
 type DbCashConnector struct{}
 
+// CheckParams ensures that all parameters are provided.
+func (connector DbCashConnector) CheckParams() (bool, error) {
+	return CheckParams()
+}
+
 // IsValidAccountNumber validates that the account number can be processed by this interface.
 func (connector DbCashConnector) IsValidAccountNumber(accountNumber string) (bool, error) {
 	isCorrectIban, _, _ := iban.IsCorrectIban(accountNumber, false)

--- a/dbapi/creditaccount.go
+++ b/dbapi/creditaccount.go
@@ -40,6 +40,11 @@ type DbCreditCardsList struct {
 // DbCreditConnector is the connector for DB Credit card accounts.
 type DbCreditConnector struct{}
 
+// CheckParams ensures that all parameters are provided.
+func (connector DbCreditConnector) CheckParams() (bool, error) {
+	return CheckParams()
+}
+
 // IsValidAccountNumber validates that the account number can be processed by this interface.
 func (connector DbCreditConnector) IsValidAccountNumber(accountNumber string) (bool, error) {
 	re := regexp.MustCompile(`^[0-9]{4}$`)

--- a/dbapi/main.go
+++ b/dbapi/main.go
@@ -18,7 +18,7 @@ var (
 	dbClientID     string = os.Getenv("DB_CLIENT_ID")
 	dbClientSecret string = os.Getenv("DB_CLIENT_SECRET")
 	dbAPIBaseURL   string = os.Getenv("DB_API_ENDPOINT_HOSTNAME")
-	redirectURL    string = os.Getenv("REDIRECT_BASE_URL") + "/authorized"
+	redirectURL    string = os.Getenv("REDIRECT_BASE_URL") + "authorized"
 	currentToken          = &oauth2.Token{}
 )
 

--- a/dbapi/main.go
+++ b/dbapi/main.go
@@ -17,12 +17,14 @@ var (
 	dbClientID     string = os.Getenv("DB_CLIENT_ID")
 	dbClientSecret string = os.Getenv("DB_CLIENT_SECRET")
 	dbAPIBaseURL   string = os.Getenv("DB_API_ENDPOINT_HOSTNAME")
+	redirectURL    string = os.Getenv("REDIRECT_BASE_URL") + "/authorized"
 	currentToken          = &oauth2.Token{}
 )
 
 var oauth2Conf = &oauth2.Config{
 	ClientID:     dbClientID,
 	ClientSecret: dbClientSecret,
+	RedirectURL:  redirectURL,
 	Scopes:       []string{"read_transactions", "read_accounts", "read_credit_cards_list_with_details", "read_credit_card_transactions", "offline_access"},
 	Endpoint: oauth2.Endpoint{
 		AuthURL:  dbAPIBaseURL + "gw/oidc/authorize",

--- a/dbapi/main.go
+++ b/dbapi/main.go
@@ -3,6 +3,7 @@ package dbapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -44,7 +45,7 @@ func Authorize() string {
 }
 
 // CheckParams ensures that all parameters are provided and fails hard if not.
-func CheckParams() {
+func CheckParams() (bool, error) {
 	var params = map[string]string{
 		"accountNumber":  accountNumber,
 		"dbClientID":     dbClientID,
@@ -52,11 +53,12 @@ func CheckParams() {
 		"dbAPIBaseURL":   dbAPIBaseURL,
 		"redirectURL":    redirectURL,
 	}
-	for i, v := range params {
+	for _, v := range params {
 		if v == "" {
-			panic("Missing/empty parameter" + i)
+			return false, errors.New("missing/empty connector parameter detected")
 		}
 	}
+	return true, nil
 }
 
 // AuthorizedHandler handles the oauth HTTP response.

--- a/dbapi/main.go
+++ b/dbapi/main.go
@@ -43,6 +43,22 @@ func Authorize() string {
 	return ""
 }
 
+// CheckParams ensures that all parameters are provided and fails hard if not.
+func CheckParams() {
+	var params = map[string]string{
+		"accountNumber":  accountNumber,
+		"dbClientID":     dbClientID,
+		"dbClientSecret": dbClientSecret,
+		"dbAPIBaseURL":   dbAPIBaseURL,
+		"redirectURL":    redirectURL,
+	}
+	for i, v := range params {
+		if v == "" {
+			panic("Missing/empty parameter" + i)
+		}
+	}
+}
+
 // AuthorizedHandler handles the oauth HTTP response.
 func AuthorizedHandler(w http.ResponseWriter, r *http.Request) {
 	var code string = r.URL.Query().Get("code")

--- a/dbapi/main_test.go
+++ b/dbapi/main_test.go
@@ -81,12 +81,10 @@ func TestCheckParams(t *testing.T) {
 			valuesWithOneEmpty := values
 			valuesWithOneEmpty[i] = ""
 			setParams(valuesWithOneEmpty)
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("The code did not panic")
-				}
-			}()
-			CheckParams()
+			_, err := CheckParams()
+			if err == nil {
+				t.Errorf("Missing parameter did not return an error")
+			}
 		}
 
 	})

--- a/dbapi/main_test.go
+++ b/dbapi/main_test.go
@@ -70,6 +70,36 @@ func TestAuthorizedHandler(t *testing.T) {
 	})
 }
 
+func TestCheckParams(t *testing.T) {
+	t.Run("Panic when missing a parameter", func(t *testing.T) {
+		var values [5]string
+		// Try checking params with each possible param empty.
+		for i := range values {
+			values[i] = "dummy_value"
+		}
+		for i := range values {
+			valuesWithOneEmpty := values
+			valuesWithOneEmpty[i] = ""
+			setParams(valuesWithOneEmpty)
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("The code did not panic")
+				}
+			}()
+			CheckParams()
+		}
+
+	})
+}
+
+func setParams(values [5]string) {
+	accountNumber = values[0]
+	dbClientID = values[1]
+	dbClientSecret = values[2]
+	dbAPIBaseURL = values[3]
+	redirectURL = values[4]
+}
+
 func setTestOauth2Config() {
 	dbAPIBaseURL = "https://example.com/"
 	oauth2Conf = &oauth2.Config{

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ type ynabTransaction = transaction.PayloadTransaction
 
 // BankConnector is the interface for any bank account connection.
 type BankConnector interface {
+	// Checks if all parameters for the connector are valid and present.
+	CheckParams() (bool, error)
 	// Checks if the account number is valid for this connector.
 	IsValidAccountNumber(string) (bool, error)
 	// Gets YNAB formatted transactions.
@@ -40,6 +42,10 @@ var (
 func main() {
 	var err error
 	activeConnector, err = GetConnector(accountNumber)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = activeConnector.CheckParams()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -29,6 +29,10 @@ type testConnector struct {
 	AuthorizationURL string
 }
 
+func (c testConnector) CheckParams() (bool, error) {
+	return true, nil
+}
+
 func (c testConnector) IsValidAccountNumber(a string) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
Not sure if I lost this in a refactoring, or if it's just different behavior for the DB sandbox vs live, but now I have to explicitly set the oauth2 redirect URI. Also added a functon to the connector to validate that all params are present and accounted for. 